### PR TITLE
Simplify configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ jobs:
       with:
         # Push back to the same branch that was checked out
         branch: ${{ github.head_ref }}
+        # This part is also where you can pass other options, for example:
+        prettier_options: --write **/*.{js,md}
 ```
 
 More documentation for writing a workflow can be found [here](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions).

--- a/README.md
+++ b/README.md
@@ -22,62 +22,36 @@ A GitHub action for styling files with [prettier](https://prettier.io).
 | commit_options | :x: | - | Custom git commit options |
 | commit_message | :x: | Prettified Code! | Custom git commit message |
 | file_pattern | :x: | * | Custom git add file pattern |
-| branch | :white_check_mark: | - | There are two types of action triggers in GitHub: on pull request and on push. The branch needs to be defined for both, but in case of the pull request trigger it should have `${{ github.head_ref }}` and on push it should have the branch the trigger is designed for. |
+| branch | :white_check_mark: | - | Always set this to `${{ github.head_ref }}` in order to work both with pull requests and push events |
 
 ### Example Config
 
-#### Example - On Pull Request
-
-This is a small example of what your `action.yml` could look like (on pull request mode):
-
 ```yaml
-name: Prettier for JS Code
+name: Continuous Integration
 
-on: [pull_request]
-
-jobs:
-  cleanup_tasks:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Cloning the repository
-      uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
-    - name: Prettify the JS Code
-      uses: creyD/prettier_action@v2.1
-      with:
-        prettier_options: '--no-semi --write *.js'
-        branch: ${{ github.head_ref }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
-
-#### Example - On Push
-
-```yaml
-name: Prettier for JS Code
-
+# This action works with pull requests and pushes
 on:
+  pull_request:
   push:
-    branches: [master]
+    branches:
+    - master
 
 jobs:
-  cleanup_tasks:
+  prettier:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Cloning the repository
-      uses: actions/checkout@v1
+    - name: Checkout
+      uses: actions/checkout@v2
       with:
-        fetch-depth: 1
-    - name: Prettify the JS Code
-      uses: creyD/prettier_action@v2.1
+        # Make sure the actual branch is checked out when running on pull requests
+        ref: ${{ github.head_ref }}
+
+    - name: Prettify code
+      uses: creyD/prettier_action@v2.2
       with:
-        prettier_options: '--no-semi --write *.js'
-        branch: master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Push back to the same branch that was checked out
+        branch: ${{ github.head_ref }}
 ```
 
 More documentation for writing a workflow can be found [here](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions).


### PR DESCRIPTION
- Remove the distinction between running on pull requests and branches. When always using `${{ github.head_ref }}`, this action works fine for both.
- Use checkout action v2
- Omit `GITHUB_TOKEN`, it works fine without passing it explicitly

Thanks for the action, it has been working great for me.