### PR TITLE
feat: allow action to use current commit instead of creating a new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,12 @@ A GitHub action for styling files with [prettier](https://prettier.io).
 | prettier_version | :x: | False | Specific prettier version (by default use latest) |
 | prettier_options | :x: | `--write **/*.js` | Prettier options (by default it applies to the whole repository) |
 | commit_options | :x: | - | Custom git commit options |
+| same_commit | :x: | False | Whether to merge into the current commit instead of creating a new one |
 | commit_message | :x: | Prettified Code! | Custom git commit message |
 | file_pattern | :x: | * | Custom git add file pattern |
 | branch (depreciated with 3.0)| :white_check_mark: | - | Always set this to `${{ github.head_ref }}` in order to work both with pull requests and push events |
+
+> Note: using the same_commit option may lead to problems if other actions are relying on the commit being the same before and after the prettier action has ran. Keep this in mind.
 
 ### Example Config
 

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: Commit message
     required: false
     default: 'Prettified Code!'
+  same_commit:
+    description: Whether to use the current commit instead of creating a new one
+    required: false
+    default: false
   commit_options:
     description: Commit options
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,7 +53,12 @@ then
     # Add changes to git
     git add "${INPUT_FILE_PATTERN}" || echo "Problem adding your files with pattern ${INPUT_FILE_PATTERN}"
     # Commit and push changes back
-    git commit -m "$INPUT_COMMIT_MESSAGE" --author="$GITHUB_ACTOR <$GITHUB_ACTOR@users.noreply.github.com>" ${INPUT_COMMIT_OPTIONS:+"$INPUT_COMMIT_OPTIONS"}
+    if $INPUT_SAME_COMMIT; then
+      echo "Amending the current commit..."
+      git commit --amend --no-edit
+    else
+      git commit -m "$INPUT_COMMIT_MESSAGE" --author="$GITHUB_ACTOR <$GITHUB_ACTOR@users.noreply.github.com>" ${INPUT_COMMIT_OPTIONS:+"$INPUT_COMMIT_OPTIONS"}
+    fi
     git push origin
     echo "Changes pushed successfully."
   fi


### PR DESCRIPTION
closes https://github.com/creyD/prettier_action/issues/16

Let me know if the implementation makes sense :). I wasn't really sure what the easiest way to test the implementation was though, so I didn't verify whether it works yet.