### PR TITLE
Install `plugin-xml` along with Prettier

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,10 +29,10 @@ _git_changed() {
 echo "Installing prettier..."
 case $INPUT_PRETTIER_VERSION in
     false)
-        npm install --silent --global prettier
+        npm install --silent --global prettier @prettier/plugin-xml
         ;;
     *)
-        npm install --silent --global prettier@$INPUT_PRETTIER_VERSION
+        npm install --silent --global prettier@$INPUT_PRETTIER_VERSION @prettier/plugin-xml
         ;;
 esac
 


### PR DESCRIPTION
_Just scratching my own itch here_ — Not sure you'll want to merge this as is, but figured I'd submit it as an example to follow up on our discussion in https://github.com/creyD/prettier_action/issues/22#issuecomment-710672420.

_(You may prefer a more universal approach that either installs multiple Prettier plugins at once, or allows the user to specify **which** plugins to install.)_

I verified that this change solves the problem I reported in #22. The resulting workflow completed without errors in https://github.com/dita-ot/docs/pull/308/checks?check_run_id=1266892894.

/cc @lipis @kddeisz 