### PR TITLE
fix: add commit and push logic after git add logic

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,6 +48,17 @@ if _git_changed; then
   else
     # Calling method to configure the git environemnt
     _git_setup
+
+    if $INPUT_ONLY_CHANGED; then
+      for file in $(git diff --name-only HEAD^..HEAD)
+      do
+        git add $file
+      done
+    else
+      # Add changes to git
+      git add "${INPUT_FILE_PATTERN}" || echo "Problem adding your files with pattern ${INPUT_FILE_PATTERN}"
+    fi
+
     # Commit and push changes back
     if $INPUT_SAME_COMMIT; then
       echo "Amending the current commit..."
@@ -55,15 +66,6 @@ if _git_changed; then
       git commit --amend --no-edit
       git push origin -f
     else
-      if $INPUT_ONLY_CHANGED; then
-        for file in $(git diff --name-only HEAD^..HEAD)
-        do
-          git add $file
-        done
-      else
-        # Add changes to git
-        git add "${INPUT_FILE_PATTERN}" || echo "Problem adding your files with pattern ${INPUT_FILE_PATTERN}"
-      fi
       git commit -m "$INPUT_COMMIT_MESSAGE" --author="$GITHUB_ACTOR <$GITHUB_ACTOR@users.noreply.github.com>" ${INPUT_COMMIT_OPTIONS:+"$INPUT_COMMIT_OPTIONS"} || echo "No files added to commit"
       git push origin
     fi


### PR DESCRIPTION
I think something went wrong with merging some conflicts in dev branch, the INPUT_SAME_COMMIT logic was placed in the else of the `git add` logic in the entrypoint.sh. At least, I didn't intend for that. 

It meant that if you set same_commit to true, that it wouldn't add the changed files to staged, so the prettier changes wouldn't be committed. I moved it below the add logic now.

I tested it here: https://github.com/jorenbroekema/prettier-action-test/commit/914ad3425ab718a3a96f8df125f1f7e78803d8c9

That commit was first only including package.json and ci.yml. After pushing that to master, the CI amended the commit and prettified the `foo.js`. Looks good to me now :)