### PR TITLE
Bump version of README to `prettier_action@v3.1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ jobs:
         ref: ${{ github.head_ref }}
 
     - name: Prettify code
-      uses: creyD/prettier_action@v3.0
+      uses: creyD/prettier_action@v3.1
       with:
         # This part is also where you can pass other options, for example:
         prettier_options: --write **/*.{js,md}
@@ -83,7 +83,7 @@ jobs:
         fetch-depth: 0
 
     - name: Prettify code
-      uses: creyD/prettier_action@v3.0
+      uses: creyD/prettier_action@v3.1
       with:
         # This part is also where you can pass other options, for example:
         prettier_options: --write **/*.{js,md}


### PR DESCRIPTION
I found that `only_changed` was available in v3.1 so the README for me was misleading as found here https://github.com/EddieJaoudeCommunity/awesome-github-profiles/pull/175

Overall though - Cool action @creyD 👍🏻 