### PR TITLE
Remove branch parameter from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ A GitHub action for styling files with [prettier](https://prettier.io).
 | same_commit | :x: | `false` | Update the current commit instead of creating a new one, created by [Joren Broekema](https://github.com/jorenbroekema), this command works only with the checkout action set to fetch depth '0' (see example 2)  |
 | commit_message | :x: | `"Prettified Code!"` | Custom git commit message, will be ignored if used with `same_commit` |
 | file_pattern | :x: | `*` | Custom git add file pattern, can't be used with only_changed! |
-| branch (deprecated with 3.0)| :white_check_mark: | - | Always set this to `${{ github.head_ref }}` in order to work both with pull requests and push events |
 | only_changed | :x: | `false` | Only prettify changed files, can't be used with file_pattern! This command works only with the checkout action set to fetch depth '0' (see example 2)|
 
 > Note: using the same_commit option may lead to problems if other actions are relying on the commit being the same before and after the prettier action has ran. Keep this in mind.


### PR DESCRIPTION
Since the parameter was removed in https://github.com/creyD/prettier_action/releases/tag/v3.0, there is no need to document it.