### PR TITLE
Handle bash globs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,7 @@
 # e is for exiting the script automatically if a command fails, u is for exiting if a variable is not set
 # x would be for showing the commands before they are executed
 set -eu
+shopt -s globstar nullglob
 
 # FUNCTIONS
 # Function for setting up git env in the docker container (copied from https://github.com/stefanzweifel/git-auto-commit-action/blob/master/entrypoint.sh)


### PR DESCRIPTION
The previous system relied on a different shell's magic for handling `*` / `**`

nullglob
- If set, Bash allows filename patterns which match no files to expand to a null string, rather than themselves.

globstar
- If set, the pattern ‘**’ used in a filename expansion context will match all files and zero or more directories and subdirectories. If the pattern is followed by a ‘/’, only directories and subdirectories match.