### PR TITLE
Fix plugin name syntax in README & description

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A GitHub action for styling files with [prettier](https://prettier.io).
 | same_commit | :x: | `false` | Update the current commit instead of creating a new one, created by [Joren Broekema](https://github.com/jorenbroekema), this command works only with the checkout action set to fetch depth '0' (see example 2)  |
 | commit_message | :x: | `"Prettified Code!"` | Custom git commit message, will be ignored if used with `same_commit` |
 | file_pattern | :x: | `*` | Custom git add file pattern, can't be used with only_changed! |
-| prettier_plugins | :x: | ` ` | Install Prettier plugins, i.e. `@prettier/prettier-php @prettier/some-other-plugin` |
+| prettier_plugins | :x: | ` ` | Install Prettier plugins, i.e. `@prettier/plugin-php @prettier/plugin-other` |
 | only_changed | :x: | `false` | Only prettify changed files, can't be used with file_pattern! This command works only with the checkout action set to fetch depth '0' (see example 2)|
 
 > Note: using the same_commit option may lead to problems if other actions are relying on the commit being the same before and after the prettier action has ran. Keep this in mind.

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ inputs:
     required: false
     default: false
   prettier_plugins:
-    description: Install Prettier plugins, i.e. `@prettier/prettier-php @prettier/some-other-plugin`
+    description: Install Prettier plugins, i.e. `@prettier/plugin-php @prettier/plugin-other`
     required: false
     default: ''
 


### PR DESCRIPTION
The entrypoint script checks for correctly named Prettier plugins on [lines 44–45](https://github.com/creyD/prettier_action/blob/master/entrypoint.sh#L44-L45), but the description in the config file and README are not consistent.

This updates those references to clarify how plugins should be specified.