### PR TITLE
Add input git push options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A GitHub action for styling files with [prettier](https://prettier.io).
 | prettier_version | :x: | `false` | Specific prettier version (by default use latest) |
 | prettier_options | :x: | `"--write **/*.js"` | Prettier options (by default it applies to the whole repository) |
 | commit_options | :x: | - | Custom git commit options |
+| push_options | :x: | - | Custom git push options |
 | same_commit | :x: | `false` | Update the current commit instead of creating a new one, created by [Joren Broekema](https://github.com/jorenbroekema), this command works only with the checkout action set to fetch depth '0' (see example 2)  |
 | commit_message | :x: | `"Prettified Code!"` | Custom git commit message, will be ignored if used with `same_commit` |
 | file_pattern | :x: | `*` | Custom git add file pattern, can't be used with only_changed! |

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,9 @@ inputs:
   commit_options:
     description: Commit options
     required: false
+  push_options:
+    description: Git push options
+    required: false
   file_pattern:
     description: File pattern used for `git add`, can't be used with only_changed!
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -81,7 +81,7 @@ if _git_changed; then
       git push origin -f
     else
       git commit -m "$INPUT_COMMIT_MESSAGE" --author="$GITHUB_ACTOR <$GITHUB_ACTOR@users.noreply.github.com>" ${INPUT_COMMIT_OPTIONS:+"$INPUT_COMMIT_OPTIONS"} || echo "No files added to commit"
-      git push origin
+      git push origin $INPUT_PUSH_OPTIONS
     fi
     echo "Changes pushed successfully."
   fi


### PR DESCRIPTION
This adds the option `push_options` for adding git push args.