### PR TITLE
Small fixes for branch dev

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,7 @@ runs:
         INPUT_PRETTIER_VERSION: ${{ inputs.prettier_version }}
         INPUT_ONLY_CHANGED: ${{ inputs.only_changed }}
         INPUT_PRETTIER_PLUGINS: ${{ inputs.prettier_plugins }}
+        INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
 
 branding:
   icon: "award"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -66,8 +66,17 @@ echo "Files:"
 prettier $INPUT_PRETTIER_OPTIONS || { PRETTIER_RESULT=$?; echo "Problem running prettier with $INPUT_PRETTIER_OPTIONS"; }
 
 # Ignore node modules and other action created files
-rm -r node_modules/ || echo "No node_modules/ folder."
-git reset --hard package-lock.json || rm package-lock.json || echo "No package-lock.json file."
+if [ -d 'node_modules' ]; then
+  rm -r node_modules/
+else
+  echo "No node_modules/ folder."
+fi
+
+if [ -f 'package-lock.json' ]; then
+  git reset --hard package-lock.json || rm package-lock.json
+else
+  echo "No package-lock.json file."
+fi
 
 # To keep runtime good, just continue if something was changed
 if _git_changed; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 # e is for exiting the script automatically if a command fails, u is for exiting if a variable is not set
 # x would be for showing the commands before they are executed
 set -eu
-shopt -s globstar nullglob
+shopt -s globstar
 
 # FUNCTIONS
 # Function for setting up git env in the docker container (copied from https://github.com/stefanzweifel/git-auto-commit-action/blob/master/entrypoint.sh)
@@ -63,7 +63,8 @@ fi
 PRETTIER_RESULT=0
 echo "Prettifying files..."
 echo "Files:"
-prettier $INPUT_PRETTIER_OPTIONS || { PRETTIER_RESULT=$?; echo "Problem running prettier with $INPUT_PRETTIER_OPTIONS"; }
+prettier $INPUT_PRETTIER_OPTIONS \
+  || { PRETTIER_RESULT=$?; echo "Problem running prettier with $INPUT_PRETTIER_OPTIONS"; exit 1; }
 
 # Ignore node modules and other action created files
 if [ -d 'node_modules' ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -109,7 +109,7 @@ if _git_changed; then
       git push origin -f
     else
       git commit -m "$INPUT_COMMIT_MESSAGE" --author="$GITHUB_ACTOR <$GITHUB_ACTOR@users.noreply.github.com>" ${INPUT_COMMIT_OPTIONS:+"$INPUT_COMMIT_OPTIONS"} || echo "No files added to commit"
-      git push origin $INPUT_PUSH_OPTIONS
+      git push origin ${INPUT_PUSH_OPTIONS:-}
     fi
     echo "Changes pushed successfully."
   fi


### PR DESCRIPTION
Hi, I've tried to use the branch `dev` in a personal project and I've found some issues throughout the process.
This PR is an attempt to fix these issues. If you think it's better to split into multiple PRs, please, let me know.

---

**Problem 1**: Missing environment variable `INPUT_GITHUB_TOKEN` even when the parameter `github_token` is set
I've added this env var following the same pattern used for the other ones.

---

**Problem 2**: Several errors are printed when prettier doesn't run successfully

i.e.
```bash
Error:  No parser and no file path given, couldn't infer a parser.
Problem running prettier with --write **/*.{ts,tsx,js,json,md}
rm: cannot remove 'node_modules/': No such file or directory
No node_modules/ folder.
fatal: ambiguous argument 'package-lock.json': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
/home/runner/work/_actions/creyD/prettier_action/dev/entrypoint.sh: line 70:  rm: command not found
No package-lock.json file.
```

Basically, this whole output is printed because we weren't checking if the generated files/directories exist before trying to delete them.

Also, before the command `rm` there was a special character, causing the `command not found` error. I've changed to whitespace.

---

**Problem 3**: Variable `INPUT_PUSH_OPTIONS` is handled as if it is required but it is not
Due to the modifier `set -u`, it's not allowed to use a variable that is not set, but this parameter is optional. Causing the error `INPUT_PUSH_OPTIONS: unbound variable` when we don't set it.
I've used an empty string as the default value when this variable is not set.

---

**Problem 4**: The action continues to run normally even when prettier doesn't run successfully, causing the action to complete without errors
I've added an `exit 1` command when prettier doesn't run successfully.

---

**Problem 5**: A generic error is printed when an invalid glob pattern is passed as parameter
When we pass an invalid pattern to the `prettier_options` parameter a generic error message is printed by prettier: `Error:  No parser and no file path given, couldn't infer a parser.`

This happens due to the shell option `nullglob` that makes bash handle this string as a null one instead of its current value.

i.e.
```yaml
prettier_options: --write **/*.{ts,tsx,json}
```

In this case, if the pattern `**/*.{ts,tsx,json}` doesn't match any file, only the flag `--write` will be passed to prettier, and the generic message will be printed.

I've removed this shell option, tested it with the same parameter, and now this message is printed: `No files matching the pattern were found: "**/**/*.{ts}".`

---

**Notes**: If you have any concerns or comments, please, let me know.