### PR TITLE
Use 'main' instead of 'master' for examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A GitHub action for styling files with [prettier](https://prettier.io).
 
 ### Example Config
 
-#### Example 1 (run on push in master)
+#### Example 1 (run on push in main)
 ```yaml
 name: Continuous Integration
 
@@ -41,7 +41,7 @@ on:
   pull_request:
   push:
     branches:
-    - master
+    - main
 
 jobs:
   prettier:
@@ -67,7 +67,7 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   prettier:
@@ -96,7 +96,7 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   prettier:
@@ -126,7 +126,7 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   prettier:


### PR DESCRIPTION
`main` is now the default branch name: https://github.com/github/renaming#new-repositories-use-main-as-the-default-branch-name

Update the examples in the docs to reflect this