### PR TITLE
Don't delete package-lock.json

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -74,7 +74,7 @@ else
 fi
 
 if [ -f 'package-lock.json' ]; then
-  git reset --hard package-lock.json || rm package-lock.json
+  git checkout -- package-lock.json
 else
   echo "No package-lock.json file."
 fi


### PR DESCRIPTION
`git reset --hard <file>` doesn't work - so package-lock.json is always deleted.

Using `git checkout -- package-lock.json` instead seems reasonable.