### PR TITLE
Update examples to use 4.1.1 instead of 4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ jobs:
         ref: ${{ github.head_ref }}
 
     - name: Prettify code
-      uses: creyD/prettier_action@v4.1
+      uses: creyD/prettier_action@v4.1.1
       with:
         # This part is also where you can pass other options, for example:
         prettier_options: --write **/*.{js,md}
@@ -86,7 +86,7 @@ jobs:
         fetch-depth: 0
 
     - name: Prettify code
-      uses: creyD/prettier_action@v4.1
+      uses: creyD/prettier_action@v4.1.1
       with:
         # This part is also where you can pass other options, for example:
         prettier_options: --write **/*.{js,md}


### PR DESCRIPTION
Update the examples so first time users don't experience the bug that was fixed by https://github.com/creyD/prettier_action/commit/26c489217918dbfb2f743734285e8cacf3960d88