### PR TITLE
fix(Plugin): don't install plugins globally

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,7 +64,7 @@ if [ -n "$INPUT_PRETTIER_PLUGINS" ]; then
             exit 1
         fi
     done
-    npm install --silent --global $INPUT_PRETTIER_PLUGINS
+    npm install --silent $INPUT_PRETTIER_PLUGINS
 fi
 )
 


### PR DESCRIPTION
This fixes a problem where `@prettier/plugin-ruby` was not being used.

Config:

```yaml
  prettier:
    runs-on: ubuntu-latest

    steps:
      - uses: actions/checkout@v2
        with:
          ref: ${{ github.head_ref }}
      - uses: creyD/prettier_action@v4.1.1
        with:
          prettier_plugins: "@prettier/plugin-ruby"
          prettier_options: "--write ."
```

**Before:**

![before](https://user-images.githubusercontent.com/669/148656158-41c62498-ec95-4910-b7a5-35ad519b6027.png)

**After:**

![after1](https://user-images.githubusercontent.com/669/148656163-4d6571d0-4018-4481-9060-58318ed88cee.png)
