### PR TITLE
Don't use the npm bin command to resolve the bin path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ runs:
     - name: Prettify code!
       shell: bash
       run: >-
-        PATH=$(cd $GITHUB_ACTION_PATH; npm bin):$PATH
+        PATH=$GITHUB_ACTION_PATH/node_modules/.bin:$PATH
         ${{ github.action_path }}/entrypoint.sh
       env:
         INPUT_COMMIT_MESSAGE: ${{ inputs.commit_message }}


### PR DESCRIPTION
This action is failing with the latest Ubuntu 22.04 image because npm updated to v9 which doesn't have the `bin` command. This change has fixed it for our repositories that are using the ubuntu image with npm v9