### PR TITLE
Allow amended commits to be empty

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -122,7 +122,7 @@ if _git_changed; then
     if $INPUT_SAME_COMMIT; then
       echo "Amending the current commit..."
       git pull
-      git commit --amend --no-edit
+      git commit --amend --no-edit --allow-empty
       git push origin -f
     else
       if [ "$INPUT_COMMIT_DESCRIPTION" != "" ]; then


### PR DESCRIPTION
When the only change made in a commit is to make the file "unpretty", running prettier on top will cause the amended commit to be empty. This throws an exception unless the --allow-empty flag is set on the git command