### PR TITLE
feat: Allow overriding actor

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A GitHub action for styling files with [prettier](https://prettier.io).
 | clean_node_folder | :x: | `true` | Delete the node_modules folder before committing |
 | only_changed | :x: | `false` | Only prettify changed files, can't be used with file_pattern! This command works only with the checkout action set to fetch depth '0' (see example 2)|
 | github_token | :x: | `${{ github.token }}` | The default [GITHUB_TOKEN](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#about-the-github_token-secret) or a [Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+| git_identity | :x: | `actions` | Set to `author` to use author's user as committer. This allows triggering [further workflow runs](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs) 
 
 > Note: using the same_commit option may lead to problems if other actions are relying on the commit being the same before and after the prettier action has ran. Keep this in mind.
 

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,10 @@ inputs:
     description: Remove the node_modules folder before committing changes
     required: false
     default: true
+  git_identity:
+    description: Which identity is used for git name/email
+    required: false
+    default: "actions"
 
 runs:
   using: "composite"
@@ -81,6 +85,7 @@ runs:
         INPUT_WORKING_DIRECTORY: ${{ inputs.working_directory }}
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
         INPUT_CLEAN_NODE_FOLDER: ${{ inputs.clean_node_folder }}
+        INPUT_GIT_IDENTITY: ${{ inputs.git_identity }}
 
 branding:
   icon: "award"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,8 +17,17 @@ _git_setup ( ) {
 EOF
     chmod 600 $HOME/.netrc
 
-    git config --global user.email "actions@github.com"
-    git config --global user.name "GitHub Action"
+    # If GIT_IDENTITY="actor"
+    if [ "$INPUT_GIT_IDENTITY" = "author" ]; then
+      git config --global user.name "$GITHUB_ACTOR"
+      git config --global user.email "$GITHUB_ACTOR@@users.noreply.github.com"
+    elif [ "$INPUT_GIT_IDENTITY" = "actions" ]; then
+      git config --global user.email "actions@github.com"
+      git config --global user.name "GitHub Action"
+    else
+      echo "GIT_IDENTITY must be either 'actor' or 'actions'";
+      exit 1;
+    fi;
 }
 
 # Checks if any files are changed


### PR DESCRIPTION
## Desired Behavior
I want to have the following behavior:
- A workflow triggers the `prettier_action`. 
- The `prettier_action` makes prettier changes and commits them back to the PR branch.
- Workflows re-run on the prettified changes, verifying the prettified changes.

## Actual Behavior
The prettier changes [don't re-trigger workflow execution](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
), because the user is set to the Actions user. 

## How this PR fixes the bug
This PR adds an option to use the author's identity, so a user can re-trigger workflows.

## Test Plan
I tested this against a private pipeline that I operate, and it worked.
