### PR TITLE
set INPUT_WORKING_DIRECTORY if not already set

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,6 +38,9 @@ _git_changed() {
 (
 # PROGRAM
 # Changing to the directory
+if [ -z "$INPUT_WORKING_DIRECTORY" ] ; then
+  INPUT_WORKING_DIRECTORY=$GITHUB_ACTION_PATH
+fi
 cd "$INPUT_WORKING_DIRECTORY"
 
 echo "Installing prettier..."


### PR DESCRIPTION
Something about 473978add96e87010e65ca5897a8d16d18df9ce8 broke prettier_action for us.  Even though everything looks right for `$INPUT_WORKING_DIRECTORY` to have a default value, so `cd "$INPUT_WORKING_DIRECTORY"` should be fine, in our usage `$INPUT_WORKING_DIRECTORY` was consistently empty.  This had a practical side effect of reporting that prettier wasn't found (because we are setting our PATH based off of `$GITHUB_ACTION_PATH`).  Adding internal default of `$GITHUB_ACTION_PATH` fixed it.  I'm happy to work with you to determine why this isn't getting set in our environment, but I ran out of things to check