### PR TITLE
allow `only_changed` and `dry` to work together

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -82,6 +82,25 @@ else
   echo "No package-lock.json file."
 fi
 
+# If running under only_changed, reset every modified file that wasn't also modified in the last commit
+# This allows only_changed and dry to work together, and simplified the non-dry logic below
+if $INPUT_ONLY_CHANGED; then
+  # list of all files changed in the previous commit
+  git diff --name-only HEAD HEAD~1 > /tmp/prev.txt
+  # list of all files with outstanding changes
+  git diff --name-only HEAD > /tmp/cur.txt
+
+  OLDIFS="$IFS"
+  IFS=$'\n'
+  # get all files that are in prev.txt that aren't also in cur.txt
+  for file in $(comm -1 -3 /tmp/prev.txt /tmp/cur.txt)
+  do
+    echo "resetting: $file"
+    git restore -- "$file"
+  done
+  IFS="$OLDIFS"
+fi
+
 # To keep runtime good, just continue if something was changed
 if _git_changed; then
   # case when --write is used with dry-run so if something is unpretty there will always have _git_changed
@@ -98,19 +117,9 @@ if _git_changed; then
     # Calling method to configure the git environemnt
     _git_setup
 
-    if $INPUT_ONLY_CHANGED; then
-      # --diff-filter=d excludes deleted files
-      OLDIFS="$IFS"
-      IFS=$'\n'
-      for file in $(git diff --name-only --diff-filter=d HEAD^..HEAD)
-      do
-        git add "$file"
-      done
-      IFS="$OLDIFS"
-    else
-      # Add changes to git
-      git add "${INPUT_FILE_PATTERN}" || echo "Problem adding your files with pattern ${INPUT_FILE_PATTERN}"
-    fi
+    # Add changes to git
+    git add "${INPUT_FILE_PATTERN}" || echo "Problem adding your files with pattern ${INPUT_FILE_PATTERN}"
+
 
     if $INPUT_NO_COMMIT; then
       echo "There are changes that won't be commited, you can use an external job to do so."


### PR DESCRIPTION
Before this change, if you tried to use `dry` and `only_changed together, it acted as if `only_changed` was ignored.  There was no code specific to `only_changed` down the `dry` code path.

This commit’s solution is to run prettier on the entire code base (as was already being done) and then, before doing any comparisons, reset changes to files that were not modified in the last commit.  This simplifies following code as there will only be outstanding changes if they were to files we care about.

It's worth noting that I _think_ as a side effect of this the note about `only_changed` and `file_pattern` being mutually exclusive is no longer correct, but I didn't test it