### PR TITLE
Add only_changed_pr

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: Git push options
     required: false
   file_pattern:
-    description: File pattern used for `git add`, can't be used with only_changed!
+    description: File pattern used for `git add`, can't be used with only_changed or only_changed_pr!
     required: false
     default: "*"
   prettier_options:
@@ -48,6 +48,10 @@ inputs:
     default: ${{ github.action_path }}
   only_changed:
     description: Only prettify files changed in the last commit, can't be used with file_pattern!
+    required: false
+    default: false
+  only_changed_pr:
+    description: Only prettify files changed in the current PR.  If specified with only_changed, only_changed will take precedent. Can't be used with file_pattern!
     required: false
     default: false
   prettier_plugins:
@@ -87,6 +91,7 @@ runs:
         INPUT_NO_COMMIT: ${{ inputs.no_commit }}
         INPUT_PRETTIER_VERSION: ${{ inputs.prettier_version }}
         INPUT_ONLY_CHANGED: ${{ inputs.only_changed }}
+        INPUT_ONLY_CHANGED_PR: ${{ inputs.only_changed_pr }}
         INPUT_PRETTIER_PLUGINS: ${{ inputs.prettier_plugins }}
         INPUT_WORKING_DIRECTORY: ${{ inputs.working_directory }}
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -84,9 +84,15 @@ fi
 
 # If running under only_changed, reset every modified file that wasn't also modified in the last commit
 # This allows only_changed and dry to work together, and simplified the non-dry logic below
-if $INPUT_ONLY_CHANGED; then
+if [ $INPUT_ONLY_CHANGED = true -o $INPUT_ONLY_CHANGED_PR = true ] ; then
+  BASE_BRANCH=origin/$GITHUB_BASE_REF
+  if $INPUT_ONLY_CHANGED; then
+    BASE_BRANCH=HEAD~1
+  fi
+
+  echo "Resetting changes, removing changes to files not changed since $BASE_BRANCH"
   # list of all files changed in the previous commit
-  git diff --name-only HEAD HEAD~1 > /tmp/prev.txt
+  git diff --name-only HEAD $BASE_BRANCH > /tmp/prev.txt
   # list of all files with outstanding changes
   git diff --name-only HEAD > /tmp/cur.txt
 
@@ -119,7 +125,6 @@ if _git_changed; then
 
     # Add changes to git
     git add "${INPUT_FILE_PATTERN}" || echo "Problem adding your files with pattern ${INPUT_FILE_PATTERN}"
-
 
     if $INPUT_NO_COMMIT; then
       echo "There are changes that won't be commited, you can use an external job to do so."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -82,6 +82,25 @@ else
   echo "No package-lock.json file."
 fi
 
+# If running under only_changed, reset every modified file that wasn't also modified in the last commit
+# This allows only_changed and dry to work together, and simplified the non-dry logic below
+if $INPUT_ONLY_CHANGED; then
+  # list of all files changed in the previous commit
+  git diff --name-only HEAD HEAD~1 > /tmp/prev.txt
+  # list of all files with outstanding changes
+  git diff --name-only HEAD > /tmp/cur.txt
+
+  OLDIFS="$IFS"
+  IFS=$'\n'
+  # get all files that are in prev.txt that aren't also in cur.txt
+  for file in $(comm -1 -3 /tmp/prev.txt /tmp/cur.txt)
+  do
+    echo "resetting: $file"
+    git restore -- "$file"
+  done
+  IFS="$OLDIFS"
+fi
+
 # To keep runtime good, just continue if something was changed
 if _git_changed; then
   # case when --write is used with dry-run so if something is unpretty there will always have _git_changed
@@ -98,19 +117,9 @@ if _git_changed; then
     # Calling method to configure the git environemnt
     _git_setup
 
-    if $INPUT_ONLY_CHANGED; then
-      # --diff-filter=d excludes deleted files
-      OLDIFS="$IFS"
-      IFS=$'\n'
-      for file in $(git diff --name-only --diff-filter=d HEAD^..HEAD)
-      do
-        git add "$file"
-      done
-      IFS="$OLDIFS"
-    else
-      # Add changes to git
-      git add "${INPUT_FILE_PATTERN}" || echo "Problem adding your files with pattern ${INPUT_FILE_PATTERN}"
-    fi
+    # Add changes to git
+    git add "${INPUT_FILE_PATTERN}" || echo "Problem adding your files with pattern ${INPUT_FILE_PATTERN}"
+
 
     if $INPUT_NO_COMMIT; then
       echo "There are changes that won't be commited, you can use an external job to do so."


### PR DESCRIPTION
This PR includes the changes for #134.  If that PR changes significantly or is rejected, this PR will need to be reworked

This PR adds new option `only_changed_pr`.  This behaves similarly to `only_changed`, except instead of only considering files which were modified in the last commit, this option only considers files which were modified in any commit included in the current PR.